### PR TITLE
Fix logo not showing up on sign in page

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -17,5 +17,7 @@ export async function middleware(request: NextRequest) {
 }
 
 export const config = {
-  matcher: ['/((?!api|_next/static|_next/image|favicon.ico).*)']
+  matcher: [
+    '/((?!api|_next/static|_next/image|favicon.ico|Diamond%20logo.png|.*\\.png$).*)'
+  ]
 };


### PR DESCRIPTION
Logo was getting blocked by middleware when not authenticated, added exception for static files.