### PR TITLE
Test github action on healthcheck endpoint

### DIFF
--- a/app/api/healthcheck/route.ts
+++ b/app/api/healthcheck/route.ts
@@ -8,27 +8,35 @@ export async function GET(request: NextRequest) {
     // Get git commit SHA for deployment
     let gitCommitSha = process.env.VERCEL_GIT_COMMIT_SHA;
     let healthData;
+    healthData = {
+      status: 'unhealthy',
+      timestamp: currentDateTime,
+      git: {
+        commit_sha: 'unknown'
+      }
+    };
+    return NextResponse.json(healthData, { status: 500 });
 
-    if (gitCommitSha && typeof gitCommitSha === 'string' && gitCommitSha.length === 40) {
-      healthData = {
-        status: 'healthy',
-        timestamp: currentDateTime,
-        git: {
-          commit_sha: gitCommitSha
-        }
-      };
-      return NextResponse.json(healthData, { status: 200 });
+    // if (gitCommitSha && typeof gitCommitSha === 'string' && gitCommitSha.length === 40) {
+    //   healthData = {
+    //     status: 'healthy',
+    //     timestamp: currentDateTime,
+    //     git: {
+    //       commit_sha: gitCommitSha
+    //     }
+    //   };
+    //   return NextResponse.json(healthData, { status: 200 });
 
-    } else {
-      healthData = {
-        status: 'unhealthy',
-        timestamp: currentDateTime,
-        git: {
-          commit_sha: 'unknown'
-        }
-      };
-      return NextResponse.json(healthData, { status: 500 });
-    }
+    // } else {
+    //   healthData = {
+    //     status: 'unhealthy',
+    //     timestamp: currentDateTime,
+    //     git: {
+    //       commit_sha: 'unknown'
+    //     }
+    //   };
+    //   return NextResponse.json(healthData, { status: 500 });
+    // }
     
   } catch (error) {
     console.error('Error retrieving health status:', error);


### PR DESCRIPTION
hardcoded unhealthy response for healthcheck route

return unhealthy status for healthcheck in a hardcoded manner for testing slack healthcheck integration.

Will be merged and deployed tomorrow for testing.
After testing the slack github action , this will be reverted to original code.
