### PR TITLE
Add github templates for feature-requests and PRs

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,31 @@
+---
+name: Feature request
+about: Feature Request summary
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+## Summary
+
+<!--- A clear and concise description of what the problem is from the perspective of the stakeholder.
+For eg.:
+* As a diamond user, I would like to be able to get logs from a failed run.
+* As a diamond developer, I would like to have auto-linting support to our PR process.
+--->
+
+## Describe the solution you'd like
+
+<!--- A clear and concise description of what you want to happen. Break down the issue to sub-issues when necessary. --->
+
+## Notes
+
+<!--- Add notes on alternative solutions, pros and cons of the approaches you've considered. --->
+
+## Checklist
+
+- [ ] Create sub-issues if needed
+- [ ] Link to parent issue if applicable
+- [ ] Assign appropriate tags (`testing`, `infrastructure`)
+- [ ] Assign an owner

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,32 @@
+## Summary
+
+<!--- Provide a summary of the changes --->
+
+## Related Issues
+<!--- List any issue numbers above that this PR addresses --->
+
+- Closes #XX
+- Related to #XX _(if applicable)_
+
+## Changes
+<!--- Check which of the following changes were made --->
+
+- [ ] Breaking (backwards incompatible changes to public interfaces)
+- [ ] Bug fix (non-breaking change which fixes an issue)
+- [ ] Enhancement (non-breaking change or feature addition)
+- [ ] Documentation (no changes to the code)
+- [ ] Infrastructure (Github actions, Testing infra etc)
+
+
+## Testing
+<!--- Please describe the test ran to verify changes --->
+
+N/A
+
+## Pull Request Checklist
+
+Please confirm the PR meets the following requirements.
+- [ ] Relevant tags are added based on the types of changes.
+- [ ] Tests have been added to show the fix is effective or that the new feature works.
+- [ ] New and existing unit tests pass locally with the changes.
+- [ ] Reviewers and Assignees are assigned.


### PR DESCRIPTION
## Summary

This PR adds support for PR and Feature request templates. This is a copy of the templates we use in the backend.

## Related Issues

- Closes https://github.com/Diamond-Proj/diamond-admin-backend/issues/59

## Changes

- [x] Enhancement (non-breaking change or feature addition)


## Testing

N/A

## Pull Request Checklist

Please confirm the PR meets the following requirements.
- [x] Relevant tags are added based on the types of changes.
~~- [ ] Tests have been added to show the fix is effective or that the new feature works.~~
~~- [ ] New and existing unit tests pass locally with the changes.~~
- [x] Reviewers and Assignees are assigned.
