### PR TITLE
Adds support for dataset name in creation and display

### DIFF
--- a/src/app/datasets/components/create-dataset-modal.tsx
+++ b/src/app/datasets/components/create-dataset-modal.tsx
@@ -7,22 +7,17 @@ import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Textarea } from '@/components/ui/textarea';
 import { useToast } from '@/components/ui/use-toast';
-import { VALID_MACHINES } from '../utils';
+import { VALID_MACHINES } from '@/app/datasets/utils';
+import {
+  CreateDatasetRequest,
+  DatasetFormData,
+  CreateDatasetApiResponse
+} from '@/app/datasets/datasets.types';
 
 interface CreateDatasetModalProps {
   isOpen: boolean;
   onClose: () => void;
   onDatasetCreated: () => void;
-}
-
-interface DatasetFormData {
-  collection_uuid: string;
-  globus_path: string;
-  system_path: string;
-  machine_name: string;
-  description: string;
-  size: string;
-  format: string;
 }
 
 export function CreateDatasetModal({
@@ -39,6 +34,7 @@ export function CreateDatasetModal({
     globus_path: '',
     system_path: '',
     machine_name: '',
+    dataset_name: '',
     description: '',
     size: '',
     format: ''
@@ -96,11 +92,12 @@ export function CreateDatasetModal({
         format: formData.format.trim() || 'Unknown'
       };
 
-      const payload = {
+      const payload: CreateDatasetRequest = {
         collection_uuid: formData.collection_uuid.trim(),
         globus_path: formData.globus_path.trim(),
         system_path: formData.system_path.trim(),
         machine_name: formData.machine_name,
+        dataset_name: formData.dataset_name.trim() || undefined,
         dataset_metadata: JSON.stringify(metadata)
       };
 
@@ -118,7 +115,7 @@ export function CreateDatasetModal({
         throw new Error(errorData.error || 'Failed to create dataset');
       }
 
-      const result = await response.json();
+      const result: CreateDatasetApiResponse = await response.json();
 
       onDatasetCreated();
 
@@ -133,6 +130,7 @@ export function CreateDatasetModal({
         globus_path: '',
         system_path: '',
         machine_name: '',
+        dataset_name: '',
         description: '',
         size: '',
         format: ''
@@ -199,6 +197,7 @@ export function CreateDatasetModal({
             <h3 className="text-lg font-medium text-gray-900 dark:text-gray-100">
               Required Information
             </h3>
+
             <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
               <div>
                 <label className="mb-2 block text-sm font-medium text-gray-700 dark:text-gray-300">
@@ -330,8 +329,25 @@ export function CreateDatasetModal({
 
           <div className="space-y-4">
             <h3 className="text-lg font-medium text-gray-900 dark:text-gray-100">
-              Optional Metadata
+              Optional Information
             </h3>
+
+            <div>
+              <label className="mb-2 block text-sm font-medium text-gray-700 dark:text-gray-300">
+                Dataset Name
+              </label>
+              <Input
+                value={formData.dataset_name}
+                onChange={(e) =>
+                  handleInputChange('dataset_name', e.target.value)
+                }
+                placeholder="e.g., My Research Dataset"
+                disabled={isLoading}
+              />
+              <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
+                A human-readable name for your dataset
+              </p>
+            </div>
 
             <div>
               <label className="mb-2 block text-sm font-medium text-gray-700 dark:text-gray-300">

--- a/src/app/datasets/components/dataset-list.tsx
+++ b/src/app/datasets/components/dataset-list.tsx
@@ -50,7 +50,9 @@ export function DatasetList({ datasets, loading }: DatasetListProps) {
 
 function DatasetListItem({ dataset }: { dataset: DisplayDataset }) {
   const { toast } = useToast();
-  const [copiedItem, setCopiedItem] = useState<'globus_path' | 'system_path' | 'uuid' | null>(null);
+  const [copiedItem, setCopiedItem] = useState<
+    'globus_path' | 'system_path' | 'uuid' | null
+  >(null);
 
   const resetCopiedItem = useMemo(
     () =>
@@ -60,7 +62,10 @@ function DatasetListItem({ dataset }: { dataset: DisplayDataset }) {
     []
   );
 
-  const copyToClipboard = async (text: string, type: 'globus_path' | 'system_path' | 'uuid') => {
+  const copyToClipboard = async (
+    text: string,
+    type: 'globus_path' | 'system_path' | 'uuid'
+  ) => {
     try {
       await navigator.clipboard.writeText(text);
 
@@ -80,9 +85,7 @@ function DatasetListItem({ dataset }: { dataset: DisplayDataset }) {
             <div className="flex h-5 w-5 items-center justify-center rounded-full bg-green-500">
               <Check className="h-3 w-3 text-white" />
             </div>
-            <span className="font-medium">
-              {typeLabels[type]} copied!
-            </span>
+            <span className="font-medium">{typeLabels[type]} copied!</span>
           </div>
         ),
         duration: 2000,
@@ -114,7 +117,7 @@ function DatasetListItem({ dataset }: { dataset: DisplayDataset }) {
         <div className="flex-1">
           <div className="mb-3 flex items-center gap-3">
             <h3 className="text-xl font-semibold text-gray-900 transition-colors duration-200 group-hover:text-purple-600 dark:text-gray-100 dark:group-hover:text-purple-400">
-              Dataset {dataset.id}
+              {dataset.dataset_name}
             </h3>
             <div className="flex items-center gap-2">
               {dataset.public ? (
@@ -176,13 +179,17 @@ function DatasetListItem({ dataset }: { dataset: DisplayDataset }) {
                 </span>
               </div>
               <button
-                onClick={() => copyToClipboard(dataset.globus_path, 'globus_path')}
+                onClick={() =>
+                  copyToClipboard(dataset.globus_path, 'globus_path')
+                }
                 className={`ml-3 cursor-pointer rounded-md p-2 transition-all duration-200 ${
                   copiedItem === 'globus_path'
                     ? 'bg-green-100 text-green-600 dark:bg-green-900/50 dark:text-green-400'
                     : 'text-gray-400 hover:bg-gray-200 hover:text-gray-600 dark:hover:bg-gray-600 dark:hover:text-gray-300'
                 }`}
-                title={copiedItem === 'globus_path' ? 'Copied!' : 'Copy Globus path'}
+                title={
+                  copiedItem === 'globus_path' ? 'Copied!' : 'Copy Globus path'
+                }
               >
                 {copiedItem === 'globus_path' ? (
                   <Check className="h-4 w-4 animate-pulse" />
@@ -202,13 +209,17 @@ function DatasetListItem({ dataset }: { dataset: DisplayDataset }) {
                 </span>
               </div>
               <button
-                onClick={() => copyToClipboard(dataset.system_path, 'system_path')}
+                onClick={() =>
+                  copyToClipboard(dataset.system_path, 'system_path')
+                }
                 className={`ml-3 cursor-pointer rounded-md p-2 transition-all duration-200 ${
                   copiedItem === 'system_path'
                     ? 'bg-green-100 text-green-600 dark:bg-green-900/50 dark:text-green-400'
                     : 'text-gray-400 hover:bg-gray-200 hover:text-gray-600 dark:hover:bg-gray-600 dark:hover:text-gray-300'
                 }`}
-                title={copiedItem === 'system_path' ? 'Copied!' : 'Copy system path'}
+                title={
+                  copiedItem === 'system_path' ? 'Copied!' : 'Copy system path'
+                }
               >
                 {copiedItem === 'system_path' ? (
                   <Check className="h-4 w-4 animate-pulse" />

--- a/src/app/datasets/datasets.types.ts
+++ b/src/app/datasets/datasets.types.ts
@@ -1,10 +1,14 @@
-export interface Dataset {
+interface DatasetBase {
   id: number;
   collection_uuid: string;
   globus_path: string;
   system_path: string;
   public: boolean;
   machine_name: string;
+  dataset_name: string;
+}
+
+export interface Dataset extends DatasetBase {
   dataset_metadata: string;
 }
 
@@ -14,14 +18,37 @@ export interface DatasetMetadata {
   format?: string;
 }
 
-export interface DisplayDataset {
-  id: number;
-  collection_uuid: string;
-  globus_path: string;
-  system_path: string;
-  public: boolean;
-  machine_name: string;
+export interface DisplayDataset extends DatasetBase {
   description: string;
   size: string;
   format: string;
+}
+
+export interface CreateDatasetRequest {
+  collection_uuid: string;
+  globus_path: string;
+  system_path: string;
+  machine_name: string;
+  dataset_name?: string;
+  dataset_metadata?: string;
+}
+
+export interface DatasetFormData {
+  collection_uuid: string;
+  globus_path: string;
+  system_path: string;
+  machine_name: string;
+  dataset_name: string;
+  description: string;
+  size: string;
+  format: string;
+}
+
+export interface DatasetsApiResponse {
+  datasets: Dataset[];
+}
+
+export interface CreateDatasetApiResponse {
+  status: string;
+  message: string;
 }

--- a/src/app/datasets/page.tsx
+++ b/src/app/datasets/page.tsx
@@ -6,7 +6,7 @@ import { CreateDatasetModal } from './components/create-dataset-modal';
 import { DatasetStats } from './components/dataset-stats';
 import { DatasetControls } from './components/dataset-controls';
 import { DatasetList } from './components/dataset-list';
-import { DisplayDataset, Dataset } from './datasets.types';
+import { DisplayDataset, Dataset, DatasetsApiResponse } from './datasets.types';
 import { transformDataset } from './utils';
 
 // Mock data for testing
@@ -101,7 +101,7 @@ export default function DatasetsPage() {
         throw new Error('Failed to fetch datasets');
       }
 
-      const data = await response.json();
+      const data: DatasetsApiResponse = await response.json();
       const transformedDatasets = data.datasets.map((dataset: Dataset) =>
         transformDataset(dataset)
       );

--- a/src/app/datasets/utils.ts
+++ b/src/app/datasets/utils.ts
@@ -16,6 +16,7 @@ export function transformDataset(dataset: Dataset): DisplayDataset {
     system_path: dataset.system_path,
     public: dataset.public,
     machine_name: dataset.machine_name,
+    dataset_name: dataset.dataset_name || `Dataset ${dataset.id}`,
     description: metadata.description || 'No description available',
     size: metadata.size || 'Unknown',
     format: metadata.format || 'Unknown'
@@ -29,4 +30,4 @@ export const VALID_MACHINES = [
   'Anvil@RCAC',
   'System@TACC',
   'System@NCSA'
-];
+] as const;


### PR DESCRIPTION
## Summary

<!--- Provide a summary of the changes --->
Enables users to specify a human-readable name for datasets during creation, improving clarity and usability when browsing or managing datasets.
Updates data model, form, and list display to handle and show dataset names, defaulting to a generic label if none provided.

## Related Issues
<!--- List any issue numbers above that this PR addresses --->

- Closes #XX
- Related to #XX _(if applicable)_

## Changes
<!--- Check which of the following changes were made --->

- [ ] Breaking (backwards incompatible changes to public interfaces)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change or feature addition)
- [ ] Documentation (no changes to the code)
- [ ] Infrastructure (Github actions, Testing infra etc)


## Testing
<!--- Please describe the test ran to verify changes --->

N/A

## Pull Request Checklist

Please confirm the PR meets the following requirements.
- [ ] Relevant tags are added based on the types of changes.
- [ ] Tests have been added to show the fix is effective or that the new feature works.
- [ ] New and existing unit tests pass locally with the changes.
- [ ] Reviewers and Assignees are assigned.
