### PR TITLE
feat(devtools): add persistent API error monitor

### DIFF
--- a/src/app/(workspace)/profile/page.tsx
+++ b/src/app/(workspace)/profile/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
-import { BadgeCheck, Bug, Building2, IdCard, Mail, Shield } from 'lucide-react';
+import { Bug, Building2, IdCard, Mail, Shield } from 'lucide-react';
+import { BrowserStorageInspector } from '@/components/profile/browser-storage-inspector';
 import { useAuthSessionContext } from '@/lib/auth/session-context';
 import { setDeveloperMode, useDeveloperMode } from '@/lib/developer-mode';
 
@@ -13,44 +14,16 @@ export default function ProfilePage() {
   const email = userInfo?.email || 'Not available';
   const username = userInfo?.username || 'Not available';
   const institution = userInfo?.organization || 'Not available';
-  const initials = name
-    .split(' ')
-    .map((value) => value[0] || '')
-    .join('')
-    .toUpperCase()
-    .slice(0, 2);
-
   return (
     <main className="flex flex-1 flex-col gap-6">
-      <section className="dashboard-card relative overflow-hidden p-5 md:p-6">
-        <div className="bg-primary/6 pointer-events-none absolute -top-14 -right-10 h-36 w-36 rounded-full blur-2xl" />
-        <div className="pointer-events-none absolute -bottom-10 -left-8 h-32 w-32 rounded-full bg-sky-400/5 blur-2xl" />
-
-        <div className="relative z-10 flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
-          <div className="flex items-center gap-4">
-            <div className="bg-primary text-primary-foreground flex h-14 w-14 items-center justify-center rounded-xl text-base font-semibold shadow-sm">
-              {initials || 'NA'}
-            </div>
-            <div>
-              <h2 className="text-xl font-semibold text-slate-900 dark:text-slate-100">
-                {name}
-              </h2>
-              <p className="text-sm text-slate-600 dark:text-slate-300">
-                {email}
-              </p>
-            </div>
-          </div>
-          <span className="inline-flex items-center gap-2 rounded-full border border-emerald-300/60 bg-emerald-50 px-3 py-1 text-xs font-semibold text-emerald-700 dark:border-emerald-700/60 dark:bg-emerald-900/25 dark:text-emerald-300">
-            <BadgeCheck className="h-3.5 w-3.5" />
-            Authenticated
-          </span>
-        </div>
-      </section>
-
       <section className="dashboard-card p-6">
         <h3 className="text-base font-semibold text-slate-900 dark:text-slate-100">
           Account Details
         </h3>
+        <p className="mt-1 text-sm leading-6 text-slate-600 dark:text-slate-300">
+          This information is managed by Globus Auth. To update it, visit your
+          Globus profile settings.
+        </p>
         <dl className="mt-4 grid grid-cols-1 gap-4 md:grid-cols-2">
           <div className="rounded-xl border border-slate-200/70 bg-slate-50/70 p-4 dark:border-slate-700/70 dark:bg-slate-900/45">
             <dt className="mb-1 flex items-center gap-2 text-xs font-semibold tracking-[0.08em] text-slate-500 uppercase dark:text-slate-400">
@@ -131,19 +104,8 @@ export default function ProfilePage() {
             />
           </button>
         </div>
-      </section>
 
-      <section className="dashboard-card p-6">
-        <h3 className="text-base font-semibold text-slate-900 dark:text-slate-100">
-          Authentication
-        </h3>
-        <p className="mt-2 text-sm text-slate-600 dark:text-slate-300">
-          This account is managed by Globus Auth. Update identity information in
-          your Globus profile settings.
-        </p>
-        <div className="mt-4 rounded-xl border border-emerald-300/60 bg-emerald-50/80 px-4 py-3 text-sm font-medium text-emerald-700 dark:border-emerald-700/60 dark:bg-emerald-900/20 dark:text-emerald-300">
-          Globus session is active.
-        </div>
+        {isDeveloperMode ? <BrowserStorageInspector /> : null}
       </section>
     </main>
   );

--- a/src/app/(workspace)/profile/page.tsx
+++ b/src/app/(workspace)/profile/page.tsx
@@ -1,10 +1,12 @@
 'use client';
 
-import { BadgeCheck, Building2, IdCard, Mail, Shield } from 'lucide-react';
+import { BadgeCheck, Bug, Building2, IdCard, Mail, Shield } from 'lucide-react';
 import { useAuthSessionContext } from '@/lib/auth/session-context';
+import { setDeveloperMode, useDeveloperMode } from '@/lib/developer-mode';
 
 export default function ProfilePage() {
   const { session } = useAuthSessionContext();
+  const isDeveloperMode = useDeveloperMode();
   const userInfo = session.userInfo;
 
   const name = userInfo?.name || 'Not available';
@@ -21,8 +23,8 @@ export default function ProfilePage() {
   return (
     <main className="flex flex-1 flex-col gap-6">
       <section className="dashboard-card relative overflow-hidden p-5 md:p-6">
-        <div className="pointer-events-none absolute -right-10 -top-14 h-36 w-36 rounded-full bg-primary/6 blur-2xl" />
-        <div className="pointer-events-none absolute -left-8 -bottom-10 h-32 w-32 rounded-full bg-sky-400/5 blur-2xl" />
+        <div className="bg-primary/6 pointer-events-none absolute -top-14 -right-10 h-36 w-36 rounded-full blur-2xl" />
+        <div className="pointer-events-none absolute -bottom-10 -left-8 h-32 w-32 rounded-full bg-sky-400/5 blur-2xl" />
 
         <div className="relative z-10 flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
           <div className="flex items-center gap-4">
@@ -90,6 +92,45 @@ export default function ProfilePage() {
             </dd>
           </div>
         </dl>
+      </section>
+
+      <section className="dashboard-card p-6">
+        <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+          <div className="flex items-start gap-3">
+            <span className="bg-primary/10 text-primary flex h-10 w-10 shrink-0 items-center justify-center rounded-lg">
+              <Bug className="h-5 w-5" aria-hidden="true" />
+            </span>
+            <div>
+              <h3 className="text-base font-semibold text-slate-900 dark:text-slate-100">
+                Developer Mode
+              </h3>
+              <p className="mt-1 max-w-3xl text-sm leading-6 text-slate-600 dark:text-slate-300">
+                Show detailed API response errors in this browser. This setting
+                is stored locally and does not affect your account.
+              </p>
+            </div>
+          </div>
+
+          <button
+            type="button"
+            role="switch"
+            aria-checked={isDeveloperMode}
+            onClick={() => setDeveloperMode(!isDeveloperMode)}
+            className={`focus-visible:ring-primary/45 relative inline-flex h-7 w-12 shrink-0 cursor-pointer rounded-full border transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none dark:focus-visible:ring-offset-slate-950 ${
+              isDeveloperMode
+                ? 'border-primary bg-primary'
+                : 'border-slate-300 bg-slate-200 dark:border-slate-600 dark:bg-slate-700'
+            }`}
+          >
+            <span className="sr-only">Toggle developer mode</span>
+            <span
+              aria-hidden="true"
+              className={`mt-0.5 block h-5.5 w-5.5 rounded-full bg-white shadow-sm transition-transform ${
+                isDeveloperMode ? 'translate-x-5.5' : 'translate-x-0.5'
+              }`}
+            />
+          </button>
+        </div>
       </section>
 
       <section className="dashboard-card p-6">

--- a/src/app/(workspace)/profile/page.tsx
+++ b/src/app/(workspace)/profile/page.tsx
@@ -1,19 +1,33 @@
 'use client';
 
-import { Bug, Building2, IdCard, Mail, Shield } from 'lucide-react';
+import { useState } from 'react';
+import { Bug, Building2, IdCard, LogOut, Mail, Shield } from 'lucide-react';
 import { BrowserStorageInspector } from '@/components/profile/browser-storage-inspector';
+import { toast } from '@/components/ui/use-toast';
 import { useAuthSessionContext } from '@/lib/auth/session-context';
 import { setDeveloperMode, useDeveloperMode } from '@/lib/developer-mode';
 
 export default function ProfilePage() {
   const { session } = useAuthSessionContext();
   const isDeveloperMode = useDeveloperMode();
+  const [isSigningOut, setIsSigningOut] = useState(false);
   const userInfo = session.userInfo;
 
   const name = userInfo?.name || 'Not available';
   const email = userInfo?.email || 'Not available';
   const username = userInfo?.username || 'Not available';
   const institution = userInfo?.organization || 'Not available';
+
+  const handleSignOut = async () => {
+    setIsSigningOut(true);
+    toast({
+      title: 'Logged out successfully',
+      description: 'You have been logged out of the Diamond service.'
+    });
+    await new Promise((resolve) => setTimeout(resolve, 350));
+    window.location.href = '/logout';
+  };
+
   return (
     <main className="flex flex-1 flex-col gap-6">
       <section className="dashboard-card p-6">
@@ -65,6 +79,26 @@ export default function ProfilePage() {
             </dd>
           </div>
         </dl>
+
+        <div className="mt-6 flex flex-col gap-4 border-t border-slate-200/70 pt-6 sm:flex-row sm:items-center sm:justify-between dark:border-slate-700/70">
+          <div>
+            <h3 className="text-sm font-semibold text-slate-900 dark:text-slate-100">
+              Account access
+            </h3>
+            <p className="mt-1 text-sm leading-6 text-slate-600 dark:text-slate-300">
+              Sign out of Diamond on this browser.
+            </p>
+          </div>
+          <button
+            type="button"
+            onClick={() => void handleSignOut()}
+            disabled={isSigningOut}
+            className="inline-flex h-10 shrink-0 cursor-pointer items-center justify-center gap-2 rounded-lg border border-rose-300 bg-white px-4 text-sm font-semibold text-rose-600 transition-colors hover:border-rose-400 hover:bg-rose-50 focus-visible:ring-2 focus-visible:ring-rose-400/40 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-60 dark:border-rose-800 dark:bg-slate-900 dark:text-rose-400 dark:hover:border-rose-700 dark:hover:bg-rose-950/30"
+          >
+            <LogOut className="h-4 w-4" aria-hidden="true" />
+            {isSigningOut ? 'Signing out...' : 'Sign out'}
+          </button>
+        </div>
       </section>
 
       <section className="dashboard-card p-6">

--- a/src/components/api-error-monitor.tsx
+++ b/src/components/api-error-monitor.tsx
@@ -1,0 +1,482 @@
+'use client';
+
+import {
+  type PointerEvent as ReactPointerEvent,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+  useSyncExternalStore
+} from 'react';
+import { AlertTriangle, Bug, Trash2, X } from 'lucide-react';
+
+import { Button } from '@/components/ui/button';
+import { useDeveloperMode } from '@/lib/developer-mode';
+
+const MAX_ERRORS = 20;
+const MAX_RESPONSE_LENGTH = 12_000;
+const API_ERRORS_STORAGE_KEY = 'diamond:api-errors';
+const API_ERRORS_CHANGE_EVENT = 'diamond:api-errors-change';
+const ERROR_TIME_FORMATTER = new Intl.DateTimeFormat(undefined, {
+  dateStyle: 'medium',
+  timeStyle: 'medium'
+});
+
+type ApiError = {
+  id: string;
+  method: string;
+  url: string;
+  status: number | null;
+  statusText: string;
+  response: string;
+  occurredAt: string;
+};
+
+type CapturedApiError = Omit<ApiError, 'id' | 'occurredAt'>;
+
+type PanelDragState = {
+  pointerId: number;
+  startX: number;
+  startY: number;
+  originX: number;
+  originY: number;
+  panelRect: DOMRect;
+};
+
+let isApiErrorMonitorOpen = false;
+const apiErrorMonitorOpenListeners = new Set<() => void>();
+
+function setApiErrorMonitorOpen(isOpen: boolean) {
+  if (isApiErrorMonitorOpen === isOpen) {
+    return;
+  }
+
+  isApiErrorMonitorOpen = isOpen;
+  apiErrorMonitorOpenListeners.forEach((listener) => listener());
+}
+
+function subscribeToApiErrorMonitorOpen(listener: () => void) {
+  apiErrorMonitorOpenListeners.add(listener);
+  return () => apiErrorMonitorOpenListeners.delete(listener);
+}
+
+function getApiErrorMonitorOpenSnapshot() {
+  return isApiErrorMonitorOpen;
+}
+
+function getApiErrorMonitorOpenServerSnapshot() {
+  return false;
+}
+
+function createApiError(error: CapturedApiError): ApiError {
+  return {
+    ...error,
+    id: crypto.randomUUID(),
+    occurredAt: new Date().toISOString()
+  };
+}
+
+function readStoredErrors() {
+  if (typeof window === 'undefined') {
+    return [];
+  }
+
+  try {
+    const storedErrors = JSON.parse(
+      localStorage.getItem(API_ERRORS_STORAGE_KEY) ?? '[]'
+    ) as ApiError[];
+
+    return Array.isArray(storedErrors) ? storedErrors.slice(0, MAX_ERRORS) : [];
+  } catch {
+    return [];
+  }
+}
+
+function getRequestDetails(input: RequestInfo | URL, init?: RequestInit) {
+  const url =
+    typeof input === 'string'
+      ? input
+      : input instanceof URL
+        ? input.toString()
+        : input.url;
+  const method =
+    init?.method ?? (input instanceof Request ? input.method : 'GET');
+
+  return { method: method.toUpperCase(), url };
+}
+
+function isLocalApiRequest(url: string) {
+  try {
+    const parsedUrl = new URL(url, window.location.origin);
+    return (
+      parsedUrl.origin === window.location.origin &&
+      parsedUrl.pathname.startsWith('/api/')
+    );
+  } catch {
+    return false;
+  }
+}
+
+async function readResponse(response: Response) {
+  const body = await response.text();
+
+  if (!body) {
+    return '(empty response body)';
+  }
+
+  let formattedBody = body;
+
+  try {
+    formattedBody = JSON.stringify(JSON.parse(body), null, 2);
+  } catch {
+    // Keep non-JSON responses as plain text.
+  }
+
+  if (formattedBody.length <= MAX_RESPONSE_LENGTH) {
+    return formattedBody;
+  }
+
+  return `${formattedBody.slice(0, MAX_RESPONSE_LENGTH)}\n… response truncated`;
+}
+
+export function ApiErrorMonitor() {
+  const isDeveloperMode = useDeveloperMode();
+
+  return isDeveloperMode ? <ActiveApiErrorMonitor /> : null;
+}
+
+export function ApiErrorMonitorTrigger() {
+  const isDeveloperMode = useDeveloperMode();
+  const [errorCount, setErrorCount] = useState(() => readStoredErrors().length);
+
+  useEffect(() => {
+    const updateErrorCount = () => setErrorCount(readStoredErrors().length);
+    const handleStorage = (event: StorageEvent) => {
+      if (event.key === API_ERRORS_STORAGE_KEY) {
+        updateErrorCount();
+      }
+    };
+
+    window.addEventListener(API_ERRORS_CHANGE_EVENT, updateErrorCount);
+    window.addEventListener('storage', handleStorage);
+
+    return () => {
+      window.removeEventListener(API_ERRORS_CHANGE_EVENT, updateErrorCount);
+      window.removeEventListener('storage', handleStorage);
+    };
+  }, []);
+
+  if (!isDeveloperMode) {
+    return null;
+  }
+
+  return (
+    <Button
+      type="button"
+      variant="outline"
+      size="default"
+      aria-controls="developer-api-diagnostics"
+      aria-label="Open developer diagnostics"
+      onClick={() => setApiErrorMonitorOpen(true)}
+      className="h-10 cursor-pointer gap-2 rounded-lg border border-slate-300/70 bg-transparent px-4 text-slate-700 transition-colors hover:bg-slate-100 hover:text-slate-900 dark:border-slate-600 dark:text-slate-200 dark:hover:bg-slate-800 dark:hover:text-slate-100"
+    >
+      <Bug className="h-4 w-4" aria-hidden="true" />
+      <span className="sr-only">Developer diagnostics</span>
+      <span className="hidden sm:inline">Dev</span>
+      <span
+        aria-label={`${errorCount} API ${errorCount === 1 ? 'error' : 'errors'}`}
+        className={`flex h-5 min-w-5 items-center justify-center rounded-full px-1 text-[0.6875rem] font-bold tabular-nums ${
+          errorCount > 0
+            ? 'bg-rose-600 text-white'
+            : 'bg-slate-200 text-slate-600 dark:bg-slate-700 dark:text-slate-300'
+        }`}
+      >
+        {errorCount}
+      </span>
+    </Button>
+  );
+}
+
+function ActiveApiErrorMonitor() {
+  const [errors, setErrors] = useState<ApiError[]>(readStoredErrors);
+  const isPanelOpen = useSyncExternalStore(
+    subscribeToApiErrorMonitorOpen,
+    getApiErrorMonitorOpenSnapshot,
+    getApiErrorMonitorOpenServerSnapshot
+  );
+  const [isDragging, setIsDragging] = useState(false);
+  const [panelOffset, setPanelOffset] = useState({ x: 0, y: 0 });
+  const panelDragState = useRef<PanelDragState | null>(null);
+
+  const handlePanelPointerDown = (event: ReactPointerEvent<HTMLDivElement>) => {
+    if (event.button !== 0 || (event.target as HTMLElement).closest('button')) {
+      return;
+    }
+
+    const panel = event.currentTarget.closest<HTMLElement>(
+      '[data-api-error-panel]'
+    );
+
+    if (!panel) {
+      return;
+    }
+
+    panelDragState.current = {
+      pointerId: event.pointerId,
+      startX: event.clientX,
+      startY: event.clientY,
+      originX: panelOffset.x,
+      originY: panelOffset.y,
+      panelRect: panel.getBoundingClientRect()
+    };
+    event.currentTarget.setPointerCapture(event.pointerId);
+    setIsDragging(true);
+    event.preventDefault();
+  };
+
+  const handlePanelPointerMove = (event: ReactPointerEvent<HTMLDivElement>) => {
+    const dragState = panelDragState.current;
+
+    if (!dragState || dragState.pointerId !== event.pointerId) {
+      return;
+    }
+
+    const nextLeft = Math.min(
+      Math.max(dragState.panelRect.left + event.clientX - dragState.startX, 8),
+      Math.max(8, window.innerWidth - dragState.panelRect.width - 8)
+    );
+    const nextTop = Math.min(
+      Math.max(dragState.panelRect.top + event.clientY - dragState.startY, 8),
+      Math.max(8, window.innerHeight - dragState.panelRect.height - 8)
+    );
+
+    setPanelOffset({
+      x: dragState.originX + nextLeft - dragState.panelRect.left,
+      y: dragState.originY + nextTop - dragState.panelRect.top
+    });
+  };
+
+  const handlePanelPointerEnd = (event: ReactPointerEvent<HTMLDivElement>) => {
+    if (panelDragState.current?.pointerId !== event.pointerId) {
+      return;
+    }
+
+    if (event.currentTarget.hasPointerCapture(event.pointerId)) {
+      event.currentTarget.releasePointerCapture(event.pointerId);
+    }
+
+    panelDragState.current = null;
+    setIsDragging(false);
+  };
+
+  useEffect(() => {
+    localStorage.setItem(API_ERRORS_STORAGE_KEY, JSON.stringify(errors));
+    window.dispatchEvent(new Event(API_ERRORS_CHANGE_EVENT));
+  }, [errors]);
+
+  useLayoutEffect(() => {
+    let isActive = true;
+    const originalFetch = window.fetch.bind(window);
+
+    const addError = (error: CapturedApiError) => {
+      if (!isActive) {
+        return;
+      }
+
+      setErrors((currentErrors) =>
+        [createApiError(error), ...currentErrors].slice(0, MAX_ERRORS)
+      );
+    };
+
+    const monitoredFetch: typeof window.fetch = async (input, init) => {
+      const { method, url } = getRequestDetails(input, init);
+      const shouldMonitor = isLocalApiRequest(url);
+
+      try {
+        const response = await originalFetch(input, init);
+
+        if (shouldMonitor && !response.ok) {
+          void readResponse(response.clone()).then((responseBody) => {
+            addError({
+              method,
+              url,
+              status: response.status,
+              statusText: response.statusText,
+              response: responseBody
+            });
+          });
+        }
+
+        return response;
+      } catch (error) {
+        if (shouldMonitor) {
+          addError({
+            method,
+            url,
+            status: null,
+            statusText: 'Network error',
+            response: error instanceof Error ? error.message : String(error)
+          });
+        }
+
+        throw error;
+      }
+    };
+
+    window.fetch = monitoredFetch;
+
+    return () => {
+      isActive = false;
+      setApiErrorMonitorOpen(false);
+      if (window.fetch === monitoredFetch) {
+        window.fetch = originalFetch;
+      }
+    };
+  }, []);
+
+  return (
+    <>
+      <p className="sr-only" aria-live="polite">
+        {errors.length > 0
+          ? `${errors.length} API ${errors.length === 1 ? 'error' : 'errors'} captured`
+          : 'No API errors captured'}
+      </p>
+
+      <aside
+        id="developer-api-diagnostics"
+        data-api-error-panel
+        role="region"
+        aria-label="API diagnostics"
+        aria-hidden={!isPanelOpen}
+        inert={isPanelOpen ? undefined : true}
+        style={{
+          transform: isPanelOpen
+            ? `translate3d(${panelOffset.x}px, calc(-50% + ${panelOffset.y}px), 0)`
+            : `translate3d(calc(${panelOffset.x}px + 100% + 1rem), calc(-50% + ${panelOffset.y}px), 0)`
+        }}
+        className={`fixed top-1/2 right-4 z-90 flex h-[min(70vh,40rem)] w-[min(calc(100vw-2rem),42rem)] flex-col overflow-hidden rounded-xl border border-slate-300/80 bg-white/97 shadow-[0_24px_80px_rgba(15,23,42,0.24)] backdrop-blur-xl will-change-transform motion-reduce:transition-none dark:border-slate-700 dark:bg-slate-950/97 ${
+          isDragging
+            ? 'transition-none'
+            : 'transition-[transform,opacity] duration-[450ms] ease-[cubic-bezier(0.22,1,0.36,1)]'
+        } ${isPanelOpen ? 'opacity-100' : 'pointer-events-none opacity-0'}`}
+      >
+        <div
+          data-testid="api-error-monitor-drag-handle"
+          onPointerDown={handlePanelPointerDown}
+          onPointerMove={handlePanelPointerMove}
+          onPointerUp={handlePanelPointerEnd}
+          onPointerCancel={handlePanelPointerEnd}
+          className={`flex touch-none items-center justify-between gap-4 border-b border-slate-200/80 bg-slate-50/85 px-4 py-3 select-none dark:border-slate-800 dark:bg-slate-900/80 ${
+            isDragging ? 'cursor-grabbing' : 'cursor-grab'
+          }`}
+        >
+          <div className="flex min-w-0 items-center gap-2.5">
+            <h2 className="truncate text-base font-semibold tracking-[0.02em] text-slate-950 [word-spacing:0.18em] dark:text-slate-100">
+              API Error Monitor
+            </h2>
+            <span
+              aria-label={`${errors.length} API ${errors.length === 1 ? 'error' : 'errors'}`}
+              className={`flex h-6 min-w-6 shrink-0 items-center justify-center rounded-full px-1.5 text-xs font-bold tabular-nums ${
+                errors.length > 0
+                  ? 'bg-rose-600 text-white'
+                  : 'bg-slate-200 text-slate-600 dark:bg-slate-700 dark:text-slate-300'
+              }`}
+            >
+              {errors.length}
+            </span>
+          </div>
+
+          <div className="flex shrink-0 items-center gap-1">
+            <div className="group relative">
+              <button
+                type="button"
+                onClick={() => setErrors([])}
+                disabled={errors.length === 0}
+                className="inline-flex h-8 w-8 cursor-pointer items-center justify-center rounded-lg text-slate-600 transition-colors hover:bg-slate-200/70 disabled:cursor-not-allowed disabled:opacity-35 dark:text-slate-300 dark:hover:bg-slate-800"
+                aria-label="Clear all API errors"
+              >
+                <Trash2 className="h-4 w-4" aria-hidden="true" />
+              </button>
+              <span
+                role="tooltip"
+                className="pointer-events-none absolute top-full right-0 z-10 mt-1.5 w-max rounded-md bg-slate-950 px-2 py-1 text-[0.6875rem] font-medium text-white opacity-0 shadow-lg transition-opacity group-focus-within:opacity-100 group-hover:opacity-100 dark:bg-slate-100 dark:text-slate-950"
+              >
+                Clear all errors
+              </span>
+            </div>
+            <button
+              type="button"
+              onClick={() => setApiErrorMonitorOpen(false)}
+              className="inline-flex h-8 w-8 cursor-pointer items-center justify-center rounded-lg text-slate-600 transition-colors hover:bg-slate-200/70 dark:text-slate-300 dark:hover:bg-slate-800"
+              aria-label="Close API diagnostics"
+            >
+              <X className="h-4 w-4" aria-hidden="true" />
+            </button>
+          </div>
+        </div>
+
+        <div className="min-h-0 flex-1 overflow-auto p-4">
+          {errors.length > 0 ? (
+            <div className="divide-y divide-slate-200 dark:divide-slate-800">
+              {errors.map((error) => (
+                <article
+                  key={error.id}
+                  role="alert"
+                  aria-label="API response error"
+                  className="space-y-3 py-4 first:pt-0 last:pb-0"
+                >
+                  <div className="flex flex-wrap items-center gap-2 text-xs">
+                    <AlertTriangle
+                      className="h-4 w-4 shrink-0 text-rose-600 dark:text-rose-400"
+                      aria-hidden="true"
+                    />
+                    <span className="rounded-md bg-slate-900 px-2 py-1 font-mono font-semibold text-white dark:bg-slate-100 dark:text-slate-950">
+                      {error.method}
+                    </span>
+                    <span className="rounded-md bg-rose-100 px-2 py-1 font-mono font-semibold text-rose-800 dark:bg-rose-950 dark:text-rose-200">
+                      {error.status ?? 'NETWORK'} {error.statusText}
+                    </span>
+                    <time
+                      dateTime={error.occurredAt}
+                      className="ml-auto text-slate-500 dark:text-slate-400"
+                    >
+                      {ERROR_TIME_FORMATTER.format(new Date(error.occurredAt))}
+                    </time>
+                    <button
+                      type="button"
+                      onClick={() =>
+                        setErrors((currentErrors) =>
+                          currentErrors.filter(
+                            (currentError) => currentError.id !== error.id
+                          )
+                        )
+                      }
+                      className="inline-flex h-7 w-7 shrink-0 cursor-pointer items-center justify-center rounded-md text-rose-700 transition-colors hover:bg-rose-100 dark:text-rose-300 dark:hover:bg-rose-950/60"
+                      aria-label="Delete API error"
+                    >
+                      <Trash2 className="h-3.5 w-3.5" aria-hidden="true" />
+                    </button>
+                  </div>
+
+                  <p className="font-mono text-xs break-all text-slate-600 dark:text-slate-300">
+                    {error.url}
+                  </p>
+
+                  <pre className="max-h-72 overflow-auto rounded-lg border border-slate-800 bg-slate-950 p-3 font-mono text-xs leading-5 break-words whitespace-pre-wrap text-rose-200">
+                    {error.response}
+                  </pre>
+                </article>
+              ))}
+            </div>
+          ) : (
+            <div className="flex h-full min-h-56 flex-col items-center justify-center text-center">
+              <h3 className="text-sm font-semibold text-slate-900 dark:text-slate-100">
+                No API errors
+              </h3>
+            </div>
+          )}
+        </div>
+      </aside>
+    </>
+  );
+}

--- a/src/components/layout/app-shell.tsx
+++ b/src/components/layout/app-shell.tsx
@@ -3,13 +3,12 @@
 import { type CSSProperties, type ReactNode, useState } from 'react';
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
-import {
-  Menu,
-  PanelLeftClose,
-  PanelLeftOpen,
-  X
-} from 'lucide-react';
+import { Menu, PanelLeftClose, PanelLeftOpen, X } from 'lucide-react';
 
+import {
+  ApiErrorMonitor,
+  ApiErrorMonitorTrigger
+} from '@/components/api-error-monitor';
 import { Logo } from '@/components/icons';
 import { AuthStatus } from '@/components/auth-status';
 import { DocsButton } from '@/components/docs-button';
@@ -27,7 +26,10 @@ const routeTitles = [
   { match: (path: string) => path.startsWith('/images'), title: 'Images' },
   { match: (path: string) => path.startsWith('/datasets'), title: 'Datasets' },
   { match: (path: string) => path.startsWith('/tasks'), title: 'Tasks' },
-  { match: (path: string) => path.startsWith('/endpoints'), title: 'Endpoints' },
+  {
+    match: (path: string) => path.startsWith('/endpoints'),
+    title: 'Endpoints'
+  },
   { match: (path: string) => path.startsWith('/profile'), title: 'Profile' }
 ];
 
@@ -74,12 +76,15 @@ export function AppShell({
           <aside className="hidden min-h-0 lg:block">
             <div className="flex h-full min-h-0 flex-col overflow-hidden border-r border-slate-200/70 bg-[hsl(var(--dashboard-surface))] dark:border-slate-700/70">
               <div
-                className={`flex h-16 shrink-0 items-center border-b border-slate-200/60 dark:border-slate-700/60 px-6`}
+                className={`flex h-16 shrink-0 items-center border-b border-slate-200/60 px-6 dark:border-slate-700/60`}
               >
-                <Link className="flex items-center gap-2 font-semibold" href="/dashboard">
+                <Link
+                  className="flex items-center gap-2 font-semibold"
+                  href="/dashboard"
+                >
                   <Logo className="drop-shadow-sm" />
                   <span
-                    className={`text-rose_red dark:text-honolulu_blue overflow-hidden whitespace-nowrap text-lg font-bold tracking-wide transition-[max-width,opacity,margin] duration-300 ease-out ${
+                    className={`text-rose_red dark:text-honolulu_blue overflow-hidden text-lg font-bold tracking-wide whitespace-nowrap transition-[max-width,opacity,margin] duration-300 ease-out ${
                       desktopNavCollapsed
                         ? 'ml-0 max-w-0 opacity-0'
                         : 'ml-1 max-w-35 opacity-100'
@@ -100,8 +105,10 @@ export function AppShell({
               <div className="flex min-w-0 items-center gap-3">
                 <button
                   type="button"
-                  className="hidden h-9 w-9 cursor-pointer items-center justify-center rounded-lg border border-slate-300/70 text-slate-700 transition-colors hover:bg-slate-100 dark:border-slate-600 dark:text-slate-200 dark:hover:bg-slate-800 lg:inline-flex"
-                  onClick={() => setDesktopNavCollapsed((collapsed) => !collapsed)}
+                  className="hidden h-9 w-9 cursor-pointer items-center justify-center rounded-lg border border-slate-300/70 text-slate-700 transition-colors hover:bg-slate-100 lg:inline-flex dark:border-slate-600 dark:text-slate-200 dark:hover:bg-slate-800"
+                  onClick={() =>
+                    setDesktopNavCollapsed((collapsed) => !collapsed)
+                  }
                   aria-label="Toggle sidebar"
                 >
                   {desktopNavCollapsed ? (
@@ -113,7 +120,7 @@ export function AppShell({
 
                 <button
                   type="button"
-                  className="inline-flex h-9 w-9 cursor-pointer items-center justify-center rounded-lg border border-slate-300/70 text-slate-700 transition-colors hover:bg-slate-100 dark:border-slate-600 dark:text-slate-200 dark:hover:bg-slate-800 lg:hidden"
+                  className="inline-flex h-9 w-9 cursor-pointer items-center justify-center rounded-lg border border-slate-300/70 text-slate-700 transition-colors hover:bg-slate-100 lg:hidden dark:border-slate-600 dark:text-slate-200 dark:hover:bg-slate-800"
                   onClick={() => setMobileNavOpen(true)}
                   aria-label="Open navigation"
                 >
@@ -125,6 +132,7 @@ export function AppShell({
               </div>
 
               <div className="flex items-center gap-3">
+                <ApiErrorMonitorTrigger />
                 <DocsButton />
                 <ThemeToggle />
                 <AuthStatus session={session} isLoading={isLoading} />
@@ -186,6 +194,7 @@ export function AppShell({
         </div>
 
         <Toaster />
+        <ApiErrorMonitor />
         <EndpointOnboarding
           isAuthenticated={session.isAuthenticated}
           primaryIdentity={session.userInfo?.id}

--- a/src/components/profile/browser-storage-inspector.tsx
+++ b/src/components/profile/browser-storage-inspector.tsx
@@ -1,0 +1,205 @@
+'use client';
+
+import { ChevronDown, Cookie, Database, HardDrive } from 'lucide-react';
+import { useState, useSyncExternalStore } from 'react';
+
+type StorageEntry = {
+  key: string;
+  value: string;
+};
+
+type BrowserStorageSnapshot = {
+  cookies: StorageEntry[];
+  localStorage: StorageEntry[];
+  sessionStorage: StorageEntry[];
+};
+
+const EMPTY_SNAPSHOT: BrowserStorageSnapshot = {
+  cookies: [],
+  localStorage: [],
+  sessionStorage: []
+};
+
+let snapshot = EMPTY_SNAPSHOT;
+const listeners = new Set<() => void>();
+
+function readStorage(storage: Storage): StorageEntry[] {
+  return Array.from({ length: storage.length }, (_, index) => {
+    const key = storage.key(index) ?? '';
+    return { key, value: storage.getItem(key) ?? '' };
+  }).sort((a, b) => a.key.localeCompare(b.key));
+}
+
+function readCookies(): StorageEntry[] {
+  if (!document.cookie) return [];
+
+  return document.cookie
+    .split(';')
+    .map((cookie) => {
+      const separatorIndex = cookie.indexOf('=');
+      const key = cookie.slice(0, separatorIndex).trim();
+      const value = cookie.slice(separatorIndex + 1);
+      return { key, value };
+    })
+    .sort((a, b) => a.key.localeCompare(b.key));
+}
+
+function refreshSnapshot() {
+  snapshot = {
+    cookies: readCookies(),
+    localStorage: readStorage(window.localStorage),
+    sessionStorage: readStorage(window.sessionStorage)
+  };
+  listeners.forEach((listener) => listener());
+}
+
+function subscribe(listener: () => void) {
+  listeners.add(listener);
+
+  if (listeners.size === 1) {
+    refreshSnapshot();
+  } else {
+    listener();
+  }
+
+  window.addEventListener('storage', refreshSnapshot);
+
+  return () => {
+    listeners.delete(listener);
+    window.removeEventListener('storage', refreshSnapshot);
+  };
+}
+
+function getSnapshot() {
+  return snapshot;
+}
+
+function getServerSnapshot() {
+  return EMPTY_SNAPSHOT;
+}
+
+const sections = [
+  { key: 'localStorage', label: 'Local storage', Icon: HardDrive },
+  { key: 'sessionStorage', label: 'Session storage', Icon: Database },
+  { key: 'cookies', label: 'Cookies', Icon: Cookie }
+] as const;
+
+function StorageTable({ entries }: { entries: StorageEntry[] }) {
+  if (entries.length === 0) {
+    return (
+      <p className="px-4 py-6 text-center text-sm text-slate-500 dark:text-slate-400">
+        No accessible entries.
+      </p>
+    );
+  }
+
+  return (
+    <div className="max-h-80 overflow-auto">
+      <table className="w-full table-fixed text-left text-xs">
+        <thead className="sticky top-0 bg-slate-100/95 text-slate-500 backdrop-blur dark:bg-slate-800/95 dark:text-slate-400">
+          <tr>
+            <th className="w-2/5 px-4 py-2 font-semibold tracking-wide uppercase">
+              Key
+            </th>
+            <th className="px-4 py-2 font-semibold tracking-wide uppercase">
+              Value
+            </th>
+          </tr>
+        </thead>
+        <tbody className="divide-y divide-slate-200/70 dark:divide-slate-700/70">
+          {entries.map(({ key, value }) => (
+            <tr key={key} className="align-top">
+              <th
+                scope="row"
+                className="px-4 py-3 font-mono font-medium break-all text-slate-800 dark:text-slate-200"
+              >
+                {key}
+              </th>
+              <td className="px-4 py-3 font-mono break-all whitespace-pre-wrap text-slate-600 dark:text-slate-300">
+                {value}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+export function BrowserStorageInspector() {
+  const [isExpanded, setIsExpanded] = useState(false);
+  const storage = useSyncExternalStore(
+    subscribe,
+    getSnapshot,
+    getServerSnapshot
+  );
+
+  return (
+    <div className="mt-6 border-t border-slate-200/70 pt-6 dark:border-slate-700/70">
+      <button
+        type="button"
+        aria-expanded={isExpanded}
+        aria-controls="browser-storage-details"
+        onClick={() => setIsExpanded((expanded) => !expanded)}
+        className="focus-visible:ring-primary/45 group -mx-2 flex w-[calc(100%+1rem)] cursor-pointer items-center justify-between gap-4 rounded-xl px-2 py-2 text-left transition-colors hover:bg-slate-50 focus-visible:ring-2 focus-visible:outline-none dark:hover:bg-slate-800/50"
+      >
+        <span className="min-w-0">
+          <span className="block text-base font-semibold text-slate-900 dark:text-slate-100">
+            Browser Storage
+          </span>
+          <span className="mt-1 block max-w-3xl text-sm leading-6 text-slate-600 dark:text-slate-300">
+            Values available to this page in the current browser tab. HttpOnly
+            cookies are intentionally hidden by the browser.
+          </span>
+        </span>
+        <span className="group-hover:border-primary/30 group-hover:text-primary flex h-9 w-9 shrink-0 items-center justify-center rounded-full border border-slate-200 bg-white text-slate-500 shadow-sm transition-colors dark:border-slate-700 dark:bg-slate-900 dark:text-slate-400">
+          <ChevronDown
+            className={`h-4 w-4 transition-transform duration-300 motion-reduce:transition-none ${
+              isExpanded ? 'rotate-180' : ''
+            }`}
+            aria-hidden="true"
+          />
+        </span>
+      </button>
+
+      <div
+        id="browser-storage-details"
+        aria-hidden={!isExpanded}
+        className={`grid transition-[grid-template-rows,opacity] duration-300 ease-out motion-reduce:transition-none ${
+          isExpanded
+            ? 'grid-rows-[1fr] opacity-100'
+            : 'grid-rows-[0fr] opacity-0'
+        }`}
+      >
+        <div className="min-h-0 overflow-hidden">
+          <div className="mt-5 space-y-4">
+            {sections.map(({ key, label, Icon }) => {
+              const entries = storage[key];
+
+              return (
+                <section
+                  key={key}
+                  className="min-w-0 overflow-hidden rounded-xl border border-slate-200/70 bg-slate-50/70 dark:border-slate-700/70 dark:bg-slate-900/45"
+                >
+                  <div className="flex items-center justify-between border-b border-slate-200/70 px-4 py-3 dark:border-slate-700/70">
+                    <h4 className="flex items-center gap-2 text-sm font-semibold text-slate-900 dark:text-slate-100">
+                      <Icon
+                        className="text-primary h-4 w-4"
+                        aria-hidden="true"
+                      />
+                      {label}
+                    </h4>
+                    <span className="rounded-full bg-slate-200/80 px-2 py-0.5 text-xs font-semibold text-slate-600 tabular-nums dark:bg-slate-700 dark:text-slate-300">
+                      {entries.length}
+                    </span>
+                  </div>
+                  <StorageTable entries={entries} />
+                </section>
+              );
+            })}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/lib/developer-mode.ts
+++ b/src/lib/developer-mode.ts
@@ -1,0 +1,45 @@
+'use client';
+
+import { useSyncExternalStore } from 'react';
+
+export const DEVELOPER_MODE_STORAGE_KEY = 'diamond:developer-mode';
+
+const DEVELOPER_MODE_CHANGE_EVENT = 'diamond:developer-mode-change';
+
+function getDeveloperModeSnapshot() {
+  return localStorage.getItem(DEVELOPER_MODE_STORAGE_KEY) === 'true';
+}
+
+function getServerSnapshot() {
+  return false;
+}
+
+function subscribeToDeveloperMode(onStoreChange: () => void) {
+  const handleStorage = (event: StorageEvent) => {
+    if (event.key === DEVELOPER_MODE_STORAGE_KEY) {
+      onStoreChange();
+    }
+  };
+  const handleLocalChange = () => onStoreChange();
+
+  window.addEventListener('storage', handleStorage);
+  window.addEventListener(DEVELOPER_MODE_CHANGE_EVENT, handleLocalChange);
+
+  return () => {
+    window.removeEventListener('storage', handleStorage);
+    window.removeEventListener(DEVELOPER_MODE_CHANGE_EVENT, handleLocalChange);
+  };
+}
+
+export function setDeveloperMode(enabled: boolean) {
+  localStorage.setItem(DEVELOPER_MODE_STORAGE_KEY, String(enabled));
+  window.dispatchEvent(new Event(DEVELOPER_MODE_CHANGE_EVENT));
+}
+
+export function useDeveloperMode() {
+  return useSyncExternalStore(
+    subscribeToDeveloperMode,
+    getDeveloperModeSnapshot,
+    getServerSnapshot
+  );
+}

--- a/tests/authenticated/dashboard.spec.ts
+++ b/tests/authenticated/dashboard.spec.ts
@@ -447,20 +447,25 @@ test.describe('Authenticated UI regression', () => {
     await page.goto('/profile');
 
     await expect(
-      page.getByRole('heading', { name: 'Test Researcher' })
+      page.getByRole('heading', { name: 'Account Details' })
     ).toBeVisible();
+    await expect(page.getByText('Test Researcher').first()).toBeVisible();
     await expect(
       page.getByText('test.researcher@example.com').first()
     ).toBeVisible();
     await expect(page.getByText('test-researcher').first()).toBeVisible();
     await expect(page.getByText('Diamond UI Test Lab').first()).toBeVisible();
-    await expect(page.getByText('Globus session is active.')).toBeVisible();
     const developerMode = page.getByRole('switch', {
       name: 'Toggle developer mode'
     });
     await expect(developerMode).not.toBeChecked();
     await developerMode.click();
     await expect(developerMode).toBeChecked();
+    const browserStorage = page.getByRole('button', {
+      name: /Browser Storage/
+    });
+    await expect(browserStorage).toBeVisible();
+    await expect(browserStorage).toHaveAttribute('aria-expanded', 'false');
     await expect(
       page.getByRole('button', { name: 'Open developer diagnostics' })
     ).toBeVisible();

--- a/tests/authenticated/dashboard.spec.ts
+++ b/tests/authenticated/dashboard.spec.ts
@@ -42,6 +42,132 @@ test.describe('Authenticated UI regression', () => {
     ).toBeVisible();
   });
 
+  test('API response errors are visible in developer mode', async ({
+    page
+  }) => {
+    await mockDashboardApi(page);
+    await page.addInitScript(() => {
+      localStorage.setItem('diamond:developer-mode', 'true');
+    });
+    await page.route('**/api/diagnostic-test', async (route) => {
+      await route.fulfill({
+        status: 422,
+        contentType: 'application/json',
+        body: JSON.stringify({ detail: 'Invalid diagnostic payload' })
+      });
+    });
+    await page.route('**/api/diagnostic-secondary', async (route) => {
+      await route.fulfill({
+        status: 503,
+        contentType: 'application/json',
+        body: JSON.stringify({ detail: 'Secondary diagnostic failure' })
+      });
+    });
+
+    await page.goto('/dashboard');
+    await expect(
+      page.getByRole('heading', { name: /Welcome back, Test/i })
+    ).toBeVisible();
+    await page
+      .getByRole('button', { name: 'Open developer diagnostics' })
+      .click();
+    const diagnosticsPanel = page.getByRole('region', {
+      name: 'API diagnostics'
+    });
+    await expect(diagnosticsPanel).toBeVisible();
+    await page.evaluate(() =>
+      Promise.all([
+        fetch('/api/diagnostic-test'),
+        fetch('/api/diagnostic-secondary')
+      ])
+    );
+
+    const diagnostics = page.getByRole('alert', {
+      name: 'API response error'
+    });
+    await expect(diagnostics).toHaveCount(2);
+    await expect(
+      diagnosticsPanel.getByRole('heading', { name: 'API Error Monitor' })
+    ).toBeVisible();
+    await expect(diagnosticsPanel).toContainText('422');
+    await expect(diagnosticsPanel).toContainText('Invalid diagnostic payload');
+    await expect(diagnosticsPanel).toContainText('503');
+    await expect(diagnosticsPanel).toContainText(
+      'Secondary diagnostic failure'
+    );
+    await page.reload();
+    await page
+      .getByRole('button', { name: 'Open developer diagnostics' })
+      .click();
+    await expect(diagnostics).toHaveCount(2);
+    await expect(diagnosticsPanel).toContainText('Invalid diagnostic payload');
+    await expect(diagnosticsPanel).toContainText(
+      'Secondary diagnostic failure'
+    );
+    await page
+      .getByRole('button', { name: 'Delete API error' })
+      .first()
+      .click();
+    await expect(diagnostics).toHaveCount(1);
+    await expect
+      .poll(() =>
+        page.evaluate(
+          () =>
+            JSON.parse(localStorage.getItem('diamond:api-errors') ?? '[]')
+              .length
+        )
+      )
+      .toBe(1);
+    const clearAllErrors = page.getByRole('button', {
+      name: 'Clear all API errors'
+    });
+    await clearAllErrors.hover();
+    await expect
+      .soft(page.getByRole('tooltip', { name: 'Clear all errors' }))
+      .toBeVisible();
+    await clearAllErrors.click();
+    await expect(diagnostics).toHaveCount(0);
+    await expect
+      .poll(() =>
+        page.evaluate(
+          () =>
+            JSON.parse(localStorage.getItem('diamond:api-errors') ?? '[]')
+              .length
+        )
+      )
+      .toBe(0);
+  });
+
+  test('API response errors stay hidden outside developer mode', async ({
+    page
+  }) => {
+    await mockDashboardApi(page);
+    await page.addInitScript(() => {
+      localStorage.setItem('diamond:developer-mode', 'false');
+    });
+    await page.route('**/api/diagnostic-test', async (route) => {
+      await route.fulfill({
+        status: 500,
+        contentType: 'application/json',
+        body: JSON.stringify({ detail: 'Internal diagnostic detail' })
+      });
+    });
+
+    await page.goto('/dashboard');
+    await expect(
+      page.getByRole('heading', { name: /Welcome back, Test/i })
+    ).toBeVisible();
+    await page.evaluate(() => fetch('/api/diagnostic-test'));
+    await page.waitForTimeout(200);
+
+    await expect(
+      page.getByRole('alert', { name: 'API response error' })
+    ).toHaveCount(0);
+    await expect(
+      page.getByRole('button', { name: 'Open developer diagnostics' })
+    ).toHaveCount(0);
+  });
+
   test('sidebar navigation keeps primary workspace routes reachable', async ({
     page
   }) => {
@@ -329,6 +455,20 @@ test.describe('Authenticated UI regression', () => {
     await expect(page.getByText('test-researcher').first()).toBeVisible();
     await expect(page.getByText('Diamond UI Test Lab').first()).toBeVisible();
     await expect(page.getByText('Globus session is active.')).toBeVisible();
+    const developerMode = page.getByRole('switch', {
+      name: 'Toggle developer mode'
+    });
+    await expect(developerMode).not.toBeChecked();
+    await developerMode.click();
+    await expect(developerMode).toBeChecked();
+    await expect(
+      page.getByRole('button', { name: 'Open developer diagnostics' })
+    ).toBeVisible();
+    await expect
+      .poll(() =>
+        page.evaluate(() => localStorage.getItem('diamond:developer-mode'))
+      )
+      .toBe('true');
   });
 
   test('auth cookie keeps linked identities compact after server writes cookies', async ({


### PR DESCRIPTION
## Summary

- add a locally stored Developer Mode toggle
- capture and persist failed API responses
- add a draggable diagnostics panel with live error counts
- support individual deletion and clearing all errors
- expose the monitor from the workspace header
- add authenticated UI regression coverage

<img width="735" height="334" alt="image" src="https://github.com/user-attachments/assets/f4df9063-4124-48f6-9fd6-fc4cfa2d7a49" />
<img width="343" height="315" alt="image" src="https://github.com/user-attachments/assets/cac564d9-bda4-4363-94f1-e67dc1f4cf93" />


<!--- Provide a summary of the changes --->

## Related Issues
<!--- List any issue numbers above that this PR addresses --->

- Closes #XX
- Related to #XX _(if applicable)_

## Changes
<!--- Check which of the following changes were made --->

- [ ] Breaking (backwards incompatible changes to public interfaces)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change or feature addition)
- [ ] Documentation (no changes to the code)
- [ ] Infrastructure (Github actions, Testing infra etc)


## Testing
<!--- Please describe the test ran to verify changes --->

N/A

## Pull Request Checklist

Please confirm the PR meets the following requirements.
- [ ] Relevant tags are added based on the types of changes.
- [ ] Tests have been added to show the fix is effective or that the new feature works.
- [ ] New and existing unit tests pass locally with the changes.
- [ ] Reviewers and Assignees are assigned.
