### PR TITLE
feat(dashboard): tailor welcome heading to profile initialization

### DIFF
--- a/src/app/(workspace)/dashboard/page.tsx
+++ b/src/app/(workspace)/dashboard/page.tsx
@@ -21,6 +21,7 @@ import { QuickActions } from '@/components/dashboard/quick-actions';
 export default function DashboardPage() {
   const [stats, setStats] = useState<DashboardStats | null>(null);
   const [recentTasks, setRecentTasks] = useState<RecentTask[]>([]);
+  const [isInitialized, setIsInitialized] = useState<boolean | null>(null);
   const [isPending, startTransition] = useTransition();
   const { session } = useAuthSessionContext();
   const user = {
@@ -64,6 +65,7 @@ export default function DashboardPage() {
   useEffect(() => {
     const checkAndUpdateProfile = async () => {
       if (!user.primaryIdentity) {
+        setIsInitialized(true);
         return;
       }
 
@@ -71,6 +73,8 @@ export default function DashboardPage() {
         const profile = await getUserProfile({
           identity_id: user.primaryIdentity
         });
+
+        setIsInitialized(profile.profile?.is_initialized ?? true);
 
         if (
           !profile.profile ||
@@ -85,6 +89,7 @@ export default function DashboardPage() {
         }
       } catch (error) {
         console.error('Error updating profile:', error);
+        setIsInitialized(true);
       }
     };
 
@@ -99,8 +104,24 @@ export default function DashboardPage() {
 
         <div className="relative z-10 flex flex-col gap-4 md:flex-row md:items-end md:justify-between">
           <div>
-            <h1 className="text-2xl font-bold text-slate-900 dark:text-slate-100">
-              Welcome back, {user.name.split(' ')[0] || 'Researcher'}
+            <h1
+              aria-busy={isInitialized === null}
+              className="text-2xl font-bold text-slate-900 dark:text-slate-100"
+            >
+              {isInitialized === null ? (
+                <>
+                  <span className="sr-only">Loading dashboard</span>
+                  <span
+                    aria-hidden="true"
+                    className="block h-8 w-56 animate-pulse rounded-lg bg-slate-200/80 dark:bg-slate-700/70"
+                  />
+                </>
+              ) : (
+                <>
+                  {isInitialized ? 'Welcome back,' : 'Welcome'}{' '}
+                  {user.name.split(' ')[0] || 'Researcher'}
+                </>
+              )}
             </h1>
           </div>
           <Link

--- a/src/app/(workspace)/dashboard/page.tsx
+++ b/src/app/(workspace)/dashboard/page.tsx
@@ -118,7 +118,7 @@ export default function DashboardPage() {
                 </>
               ) : (
                 <>
-                  {isInitialized ? 'Welcome back,' : 'Welcome'}{' '}
+                  {isInitialized ? 'Welcome back,' : 'Welcome,'}{' '}
                   {user.name.split(' ')[0] || 'Researcher'}
                 </>
               )}

--- a/src/app/(workspace)/dashboard/page.tsx
+++ b/src/app/(workspace)/dashboard/page.tsx
@@ -65,7 +65,7 @@ export default function DashboardPage() {
   useEffect(() => {
     const checkAndUpdateProfile = async () => {
       if (!user.primaryIdentity) {
-        setIsInitialized(true);
+        // Keep heading in loading state until the auth session resolves an identity.
         return;
       }
 

--- a/src/app/(workspace)/dashboard/page.tsx
+++ b/src/app/(workspace)/dashboard/page.tsx
@@ -74,7 +74,7 @@ export default function DashboardPage() {
           identity_id: user.primaryIdentity
         });
 
-        setIsInitialized(profile.profile?.is_initialized ?? true);
+        setIsInitialized(profile.profile?.is_initialized ?? false);
 
         if (
           !profile.profile ||

--- a/tests/authenticated/dashboard.spec.ts
+++ b/tests/authenticated/dashboard.spec.ts
@@ -42,6 +42,33 @@ test.describe('Authenticated UI regression', () => {
     ).toBeVisible();
   });
 
+  test('dashboard welcomes users who have not completed initialization', async ({
+    page
+  }) => {
+    await mockDashboardApi(page);
+    await page.route('**/api/profile**', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          profile: {
+            identity_id: 'test-user-identity',
+            name: 'Test Researcher',
+            email: 'test.researcher@example.com',
+            institution: 'Diamond UI Test Lab',
+            is_initialized: false
+          }
+        })
+      });
+    });
+
+    await page.goto('/dashboard');
+
+    await expect(
+      page.getByRole('heading', { name: /^Welcome Test$/i })
+    ).toBeVisible();
+  });
+
   test('sidebar navigation keeps primary workspace routes reachable', async ({
     page
   }) => {

--- a/tests/authenticated/dashboard.spec.ts
+++ b/tests/authenticated/dashboard.spec.ts
@@ -65,7 +65,7 @@ test.describe('Authenticated UI regression', () => {
     await page.goto('/dashboard');
 
     await expect(
-      page.getByRole('heading', { name: /^Welcome Test$/i })
+      page.getByRole('heading', { name: /^Welcome, Test$/i })
     ).toBeVisible();
   });
 


### PR DESCRIPTION
## Summary

- track the user profile initialization state
- show a loading skeleton while the profile is being resolved
- display “Welcome” for new users and “Welcome back” for initialized users
- add accessible loading semantics to the dashboard heading
- preserve the initialized experience when profile loading fails

### Not initialized
<img width="175" height="68" alt="image" src="https://github.com/user-attachments/assets/e3f9c34d-d8b3-42bb-8282-69a4fa0241e6" />

### Initialized
<img width="193" height="71" alt="image" src="https://github.com/user-attachments/assets/d61fbf87-c681-4ff3-a755-14401eacffe6" />

<!--- Provide a summary of the changes --->

## Related Issues
<!--- List any issue numbers above that this PR addresses --->

- Closes #XX
- Related to #XX _(if applicable)_

## Changes
<!--- Check which of the following changes were made --->

- [ ] Breaking (backwards incompatible changes to public interfaces)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change or feature addition)
- [ ] Documentation (no changes to the code)
- [ ] Infrastructure (Github actions, Testing infra etc)


## Testing
<!--- Please describe the test ran to verify changes --->

N/A

## Pull Request Checklist

Please confirm the PR meets the following requirements.
- [ ] Relevant tags are added based on the types of changes.
- [ ] Tests have been added to show the fix is effective or that the new feature works.
- [ ] New and existing unit tests pass locally with the changes.
- [ ] Reviewers and Assignees are assigned.
