### PR TITLE
[bug]dataset metadata can be null

### DIFF
--- a/src/app/(workspace)/datasets/datasets.types.ts
+++ b/src/app/(workspace)/datasets/datasets.types.ts
@@ -9,7 +9,7 @@ interface DatasetBase {
 }
 
 export interface Dataset extends DatasetBase {
-  dataset_metadata: string;
+  dataset_metadata: string | null;
 }
 
 export interface DatasetMetadata {

--- a/src/app/(workspace)/datasets/utils.ts
+++ b/src/app/(workspace)/datasets/utils.ts
@@ -3,10 +3,12 @@ import { Dataset, DatasetMetadata, DisplayDataset } from './datasets.types';
 export function transformDataset(dataset: Dataset): DisplayDataset {
   let metadata: DatasetMetadata = {};
 
-  try {
-    metadata = JSON.parse(dataset.dataset_metadata);
-  } catch (error) {
-    console.warn('Failed to parse dataset metadata:', error);
+  if (dataset.dataset_metadata) {
+    try {
+      metadata = JSON.parse(dataset.dataset_metadata) ?? {};
+    } catch (error) {
+      console.warn('Failed to parse dataset metadata:', error);
+    }
   }
 
   return {

--- a/src/app/(workspace)/tasks/tasks.types.ts
+++ b/src/app/(workspace)/tasks/tasks.types.ts
@@ -89,7 +89,7 @@ export interface Dataset {
   public: boolean;
   machine_name: string;
   dataset_name: string;
-  dataset_metadata: string;
+  dataset_metadata: string | null;
 }
 
 export interface DatasetsApiResponse {


### PR DESCRIPTION
## Summary

dataset metadata json parsing now checks for null
Dataset metadata can be null/empty

## Related Issues
<!--- List any issue numbers above that this PR addresses --->

- Closes #188 

## Changes
<!--- Check which of the following changes were made --->

- [ ] Breaking (backwards incompatible changes to public interfaces)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change or feature addition)
- [ ] Documentation (no changes to the code)
- [ ] Infrastructure (Github actions, Testing infra etc)


## Testing
<!--- Please describe the test ran to verify changes --->

N/A

## Pull Request Checklist

Please confirm the PR meets the following requirements.
- [ ] Relevant tags are added based on the types of changes.
- [ ] Tests have been added to show the fix is effective or that the new feature works.
- [ ] New and existing unit tests pass locally with the changes.
- [ ] Reviewers and Assignees are assigned.
