### PR TITLE
Add contact page and team communication links

### DIFF
--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -1,0 +1,229 @@
+import type { Metadata } from 'next';
+import Link from 'next/link';
+import { GitHubLogoIcon } from '@radix-ui/react-icons';
+import { ArrowUpRight, Mail } from 'lucide-react';
+
+import { LandingHeader } from '@/components/landing/landing-header';
+import { LandingFooter } from '@/components/landing/landing-footer';
+import contact from '@/content/contact.json';
+import { landingPageContent } from '@/content/landing-page-content';
+
+export const metadata: Metadata = {
+  title: 'Contact us',
+  description:
+    'Contact the Diamond HPC team or contribute to the frontend project on GitHub.'
+};
+
+const focusRing =
+  'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/45 focus-visible:ring-offset-2 dark:focus-visible:ring-offset-slate-950';
+
+const primaryAction = `contact-action group inline-flex min-h-11 items-center justify-center gap-2 rounded-lg bg-[#c90a37] px-4 text-sm font-semibold text-white shadow-[0_10px_24px_rgba(201,10,55,0.14)] hover:bg-[#b50931] hover:shadow-[0_14px_28px_rgba(201,10,55,0.2)] ${focusRing}`;
+
+const secondaryAction = `contact-action group inline-flex min-h-11 items-center justify-center gap-2 rounded-lg bg-white/60 px-4 text-sm font-semibold text-slate-700 hover:bg-white hover:text-slate-950 dark:bg-slate-900/65 dark:text-slate-300 dark:hover:bg-slate-900 dark:hover:text-white ${focusRing}`;
+
+function SlackLogo({ className }: { className?: string }) {
+  return (
+    <svg viewBox="0 0 54.9 54.9" className={className} aria-hidden="true">
+      <path
+        fill="#E01E5A"
+        d="M12.2 34.5c0 3.4-2.7 6.1-6.1 6.1S0 37.9 0 34.5s2.7-6.1 6.1-6.1h6.1v6.1Zm3.1 0c0-3.4 2.7-6.1 6.1-6.1s6.1 2.7 6.1 6.1v15.3c0 3.4-2.7 6.1-6.1 6.1s-6.1-2.7-6.1-6.1V34.5Z"
+      />
+      <path
+        fill="#36C5F0"
+        d="M21.4 12.2c-3.4 0-6.1-2.7-6.1-6.1S18 0 21.4 0s6.1 2.7 6.1 6.1v6.1h-6.1Zm0 3.1c3.4 0 6.1 2.7 6.1 6.1s-2.7 6.1-6.1 6.1H6.1C2.7 27.5 0 24.8 0 21.4s2.7-6.1 6.1-6.1h15.3Z"
+      />
+      <path
+        fill="#2EB67D"
+        d="M42.8 21.4c0-3.4 2.7-6.1 6.1-6.1s6.1 2.7 6.1 6.1-2.7 6.1-6.1 6.1h-6.1v-6.1Zm-3.1 0c0 3.4-2.7 6.1-6.1 6.1s-6.1-2.7-6.1-6.1V6.1c0-3.4 2.7-6.1 6.1-6.1s6.1 2.7 6.1 6.1v15.3Z"
+      />
+      <path
+        fill="#ECB22E"
+        d="M33.6 42.8c3.4 0 6.1 2.7 6.1 6.1s-2.7 6.1-6.1 6.1-6.1-2.7-6.1-6.1v-6.1h6.1Zm0-3.1c-3.4 0-6.1-2.7-6.1-6.1s2.7-6.1 6.1-6.1h15.3c3.4 0 6.1 2.7 6.1 6.1s-2.7 6.1-6.1 6.1H33.6Z"
+      />
+    </svg>
+  );
+}
+
+function Rule() {
+  return (
+    <span
+      aria-hidden="true"
+      className="block h-px bg-slate-300/90 dark:bg-slate-700"
+    />
+  );
+}
+
+export default function ContactPage() {
+  return (
+    <main className="relative min-h-screen overflow-hidden bg-[#f4f6f9] text-slate-950 dark:bg-[#0b1018] dark:text-slate-50">
+      <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_top_left,rgba(201,10,55,0.08),transparent_25%),radial-gradient(circle_at_top_right,rgba(14,121,178,0.06),transparent_29%),linear-gradient(180deg,#f3f6fa_0%,#f7f9fc_42%,#f4f6f9_100%)] dark:bg-[radial-gradient(circle_at_top_left,rgba(201,10,55,0.12),transparent_24%),radial-gradient(circle_at_top_right,rgba(14,121,178,0.09),transparent_28%),linear-gradient(180deg,#0b1018_0%,#0d1320_42%,#101623_100%)]" />
+      <div className="pointer-events-none absolute inset-0 bg-[linear-gradient(to_right,rgba(100,116,139,0.12)_1px,transparent_1px),linear-gradient(to_bottom,rgba(100,116,139,0.12)_1px,transparent_1px)] [mask-image:linear-gradient(to_bottom,white,transparent_82%)] bg-size-[56px_56px] opacity-45 dark:opacity-25" />
+
+      <LandingHeader header={landingPageContent.header} showContact={false} />
+
+      <div className="relative z-10 container pt-32 pb-16 md:pt-40 md:pb-20">
+        <div className="mx-auto max-w-6xl">
+          <h1 className="max-w-3xl text-[clamp(2.25rem,4.5vw,4.25rem)] leading-[0.98] font-semibold tracking-[-0.055em]">
+            {contact.page.title}
+          </h1>
+
+          <div className="mt-12">
+            <section className="contact-channel grid gap-6 py-8 lg:grid-cols-[4rem_13rem_minmax(0,1fr)] lg:py-10">
+              <p className="contact-channel-number font-mono text-xs font-semibold text-[#c90a37] dark:text-rose-400">
+                01
+              </p>
+              <div className="contact-channel-heading flex items-center gap-3 lg:items-start">
+                <SlackLogo className="h-6 w-6 shrink-0" />
+                <h2 className="text-lg font-semibold tracking-[-0.025em]">
+                  {contact.slack.label}
+                </h2>
+              </div>
+              <div className="contact-channel-content">
+                {contact.slack.joinUrl ? (
+                  <Link
+                    href={contact.slack.joinUrl}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className={primaryAction}
+                  >
+                    Join Slack
+                    <ArrowUpRight
+                      className="h-4 w-4 transition-transform duration-[220ms] ease-out group-hover:translate-x-0.5 group-hover:-translate-y-0.5"
+                      aria-hidden="true"
+                    />
+                  </Link>
+                ) : (
+                  <p className="inline-flex items-center gap-2 text-sm text-slate-600 dark:text-slate-300">
+                    <span className="h-1.5 w-1.5 rounded-full bg-slate-400" />
+                    {contact.slack.status}
+                  </p>
+                )}
+              </div>
+            </section>
+
+            <Rule />
+
+            <section className="contact-channel grid gap-6 py-8 lg:grid-cols-[4rem_13rem_minmax(0,1fr)] lg:py-10">
+              <p className="contact-channel-number font-mono text-xs font-semibold text-[#c90a37] dark:text-rose-400">
+                02
+              </p>
+              <div className="contact-channel-heading flex items-center gap-3 lg:items-start">
+                <GitHubLogoIcon
+                  className="h-6 w-6 shrink-0"
+                  aria-hidden="true"
+                />
+                <h2 className="text-lg font-semibold tracking-[-0.025em]">
+                  GitHub
+                </h2>
+              </div>
+              <div className="contact-channel-content">
+                {contact.github.map((repository, index) => (
+                  <article
+                    key={`${repository.repositoryUrl}-${index}`}
+                    className={
+                      index === 0
+                        ? undefined
+                        : 'mt-7 border-t border-slate-300/80 pt-7 dark:border-slate-700'
+                    }
+                  >
+                    <h3 className="text-xl font-semibold tracking-[-0.03em]">
+                      {repository.label}
+                    </h3>
+                    <div className="mt-5 flex flex-wrap gap-2">
+                      <Link
+                        href={repository.issuesUrl}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className={primaryAction}
+                      >
+                        New issue
+                        <ArrowUpRight
+                          className="h-4 w-4 transition-transform duration-[220ms] ease-out group-hover:translate-x-0.5 group-hover:-translate-y-0.5"
+                          aria-hidden="true"
+                        />
+                      </Link>
+                      <Link
+                        href={repository.repositoryUrl}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className={secondaryAction}
+                      >
+                        Repository
+                        <ArrowUpRight
+                          className="h-4 w-4 transition-transform duration-[220ms] ease-out group-hover:translate-x-0.5 group-hover:-translate-y-0.5"
+                          aria-hidden="true"
+                        />
+                      </Link>
+                      <Link
+                        href={repository.pullRequestsUrl}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className={secondaryAction}
+                      >
+                        Pull requests
+                        <ArrowUpRight
+                          className="h-4 w-4 transition-transform duration-[220ms] ease-out group-hover:translate-x-0.5 group-hover:-translate-y-0.5"
+                          aria-hidden="true"
+                        />
+                      </Link>
+                    </div>
+                  </article>
+                ))}
+              </div>
+            </section>
+
+            <Rule />
+
+            <section className="contact-channel grid gap-6 py-8 lg:grid-cols-[4rem_13rem_minmax(0,1fr)] lg:py-10">
+              <p className="contact-channel-number font-mono text-xs font-semibold text-[#c90a37] dark:text-rose-400">
+                03
+              </p>
+              <div className="contact-channel-heading flex items-center gap-3 lg:items-start">
+                <Mail
+                  className="h-6 w-6 shrink-0 text-[#c90a37] dark:text-rose-400"
+                  aria-hidden="true"
+                />
+                <h2 className="text-lg font-semibold tracking-[-0.025em]">
+                  Email
+                </h2>
+              </div>
+              <div className="contact-channel-content">
+                {contact.emails.map((person, index) => (
+                  <article
+                    key={`${person.email}-${index}`}
+                    className={
+                      index === 0
+                        ? undefined
+                        : 'mt-9 border-t border-slate-300/80 pt-9 dark:border-slate-700'
+                    }
+                  >
+                    <div className="flex flex-wrap items-baseline gap-x-3 gap-y-1">
+                      <h3 className="text-2xl font-semibold tracking-[-0.035em]">
+                        {person.name}
+                      </h3>
+                      <p className="text-sm leading-6 text-slate-500 dark:text-slate-400">
+                        {person.role}
+                      </p>
+                    </div>
+                    <p className="mt-5 text-sm leading-7 text-slate-600 dark:text-slate-300">
+                      {person.bio}
+                    </p>
+                    <Link
+                      href={`mailto:${person.email}`}
+                      aria-label={`Email ${person.name}`}
+                      className={`${primaryAction} mt-6`}
+                    >
+                      <Mail className="h-4 w-4" aria-hidden="true" />
+                      {person.email}
+                    </Link>
+                  </article>
+                ))}
+              </div>
+            </section>
+          </div>
+        </div>
+      </div>
+      <LandingFooter />
+    </main>
+  );
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -500,4 +500,85 @@
       0 18px 36px hsl(222 60% 2% / 0.55),
       inset 0 1px 0 hsl(0 0% 100% / 0.03);
   }
+
+  .contact-channel {
+    position: relative;
+    isolation: isolate;
+    transition: padding-block 420ms cubic-bezier(0.22, 1, 0.36, 1);
+  }
+
+  .contact-channel::before {
+    position: absolute;
+    z-index: -1;
+    inset: 0 -1.5rem;
+    border-radius: 1.5rem;
+    background: linear-gradient(
+      90deg,
+      transparent,
+      hsl(var(--primary) / 0.055) 18%,
+      hsl(var(--primary) / 0.025) 72%,
+      transparent
+    );
+    content: '';
+    opacity: 0;
+    transform: scaleY(0.82);
+    transition:
+      opacity 360ms ease-out,
+      transform 420ms cubic-bezier(0.22, 1, 0.36, 1);
+  }
+
+  .contact-channel-number,
+  .contact-channel-heading,
+  .contact-channel-content {
+    transform-origin: left center;
+    transition:
+      color 320ms ease-out,
+      transform 420ms cubic-bezier(0.22, 1, 0.36, 1);
+  }
+
+  .contact-action {
+    transition:
+      color 220ms ease-out,
+      background-color 220ms ease-out,
+      box-shadow 220ms ease-out,
+      transform 220ms cubic-bezier(0.22, 1, 0.36, 1);
+  }
+
+  @media (hover: hover) and (prefers-reduced-motion: no-preference) {
+    .contact-channel:hover {
+      padding-block: 3.75rem;
+    }
+
+    .contact-channel:hover::before {
+      opacity: 1;
+      transform: scaleY(1);
+    }
+
+    .contact-channel:hover .contact-channel-number {
+      transform: translateX(0.25rem) scale(1.35);
+    }
+
+    .contact-channel:hover .contact-channel-heading {
+      transform: translateX(0.2rem) scale(1.055);
+    }
+
+    .contact-channel:hover .contact-channel-content {
+      transform: translateX(0.3rem) scale(1.012);
+    }
+
+    .contact-action:hover {
+      transform: translateY(-0.125rem);
+    }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .contact-channel,
+    .contact-channel::before,
+    .contact-channel-number,
+    .contact-channel-heading,
+    .contact-channel-content,
+    .contact-action {
+      transition-duration: 0.01ms;
+    }
+  }
 }

--- a/src/components/landing/landing-footer.tsx
+++ b/src/components/landing/landing-footer.tsx
@@ -1,0 +1,48 @@
+import Link from 'next/link';
+
+import { Logo } from '@/components/icons';
+import contact from '@/content/contact.json';
+
+export function LandingFooter() {
+  return (
+    <footer className="relative z-10 border-t border-slate-200/60 bg-[linear-gradient(180deg,rgba(244,246,249,0.6),rgba(240,243,247,0.9))] backdrop-blur-xl dark:border-slate-800/60 dark:bg-[linear-gradient(180deg,rgba(11,16,24,0.6),rgba(8,12,20,0.9))]">
+      <div className="container py-6 md:py-8">
+        <div className="flex flex-col items-center justify-between gap-6 md:flex-row">
+          <div className="flex items-center gap-3">
+            <Logo width={28} height={28} className="shrink-0 opacity-70" />
+            <span className="text-sm font-medium text-slate-500 dark:text-slate-400">
+              Diamond HPC
+            </span>
+          </div>
+
+          <nav className="flex flex-wrap items-center justify-center gap-x-6 gap-y-2">
+            <Link
+              href={contact.navigation.href}
+              className="text-sm text-slate-500 transition-colors hover:text-slate-700 dark:text-slate-400 dark:hover:text-slate-200"
+            >
+              {contact.navigation.label}
+            </Link>
+            <Link
+              href="https://docs.diamondhpc.ai"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-sm text-slate-500 transition-colors hover:text-slate-700 dark:text-slate-400 dark:hover:text-slate-200"
+            >
+              Docs
+            </Link>
+            <Link
+              href="/dashboard"
+              className="text-sm text-slate-500 transition-colors hover:text-slate-700 dark:text-slate-400 dark:hover:text-slate-200"
+            >
+              Workspace
+            </Link>
+          </nav>
+
+          <p className="text-xs text-slate-400 dark:text-slate-500">
+            &copy; {new Date().getFullYear()} Diamond HPC
+          </p>
+        </div>
+      </div>
+    </footer>
+  );
+}

--- a/src/components/landing/landing-header.tsx
+++ b/src/components/landing/landing-header.tsx
@@ -6,6 +6,7 @@ import { useEffect, useRef, useState } from 'react';
 import { Logo } from '@/components/icons';
 import ThemeToggle from '@/components/layout/theme-toggle';
 import type { LandingPageContent } from '@/content/landing-page-content';
+import contact from '@/content/contact.json';
 
 function HeaderActionLink({
   href,
@@ -40,9 +41,11 @@ function PrimaryHeaderCta({ href, label }: { href: string; label: string }) {
 }
 
 export function LandingHeader({
-  header
+  header,
+  showContact = true
 }: {
   header: LandingPageContent['header'];
+  showContact?: boolean;
 }) {
   const [isVisible, setIsVisible] = useState(true);
   const lastScrollY = useRef(0);
@@ -79,7 +82,11 @@ export function LandingHeader({
     >
       <div className="container py-4">
         <div className="mx-auto flex max-w-[1240px] items-center justify-between gap-4 rounded-xl border border-white/70 bg-white/64 px-4 py-3 shadow-[0_24px_80px_rgba(15,23,42,0.08)] backdrop-blur-2xl md:px-5 dark:border-slate-800/80 dark:bg-slate-950/72 dark:shadow-[0_28px_90px_rgba(2,6,23,0.4)]">
-          <div className="flex min-w-0 items-center gap-3">
+          <Link
+            href="/"
+            aria-label="Diamond HPC home"
+            className="focus-visible:ring-primary/45 flex min-w-0 items-center gap-3 rounded-lg focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none dark:focus-visible:ring-offset-slate-950"
+          >
             <div className="rounded-lg border border-white/80 bg-white/78 p-1.5 shadow-[0_8px_24px_rgba(15,23,42,0.08)] dark:border-slate-800/80 dark:bg-slate-900/86 dark:shadow-none">
               <Logo width={42} height={42} className="shrink-0" />
             </div>
@@ -91,9 +98,15 @@ export function LandingHeader({
                 {header.label}
               </p>
             </div>
-          </div>
+          </Link>
 
           <div className="flex items-center gap-2">
+            {showContact ? (
+              <HeaderActionLink
+                href={contact.navigation.href}
+                label={contact.navigation.label}
+              />
+            ) : null}
             <HeaderActionLink
               href={header.docsHref}
               label={header.docsLabel}

--- a/src/components/landing/landing-page.tsx
+++ b/src/components/landing/landing-page.tsx
@@ -9,7 +9,7 @@ import {
   Rocket
 } from 'lucide-react';
 
-import { Logo } from '@/components/icons';
+import { LandingFooter } from '@/components/landing/landing-footer';
 import { LandingHeader } from '@/components/landing/landing-header';
 import { LandingReveal } from '@/components/landing/landing-reveal';
 import { landingPageContent } from '@/content/landing-page-content';
@@ -326,39 +326,7 @@ export function LandingPage() {
         </section>
       </div>
 
-      <footer className="relative z-10 border-t border-slate-200/60 bg-[linear-gradient(180deg,rgba(244,246,249,0.6),rgba(240,243,247,0.9))] backdrop-blur-xl dark:border-slate-800/60 dark:bg-[linear-gradient(180deg,rgba(11,16,24,0.6),rgba(8,12,20,0.9))]">
-        <div className="container py-6 md:py-8">
-          <div className="flex flex-col items-center justify-between gap-6 md:flex-row">
-            <div className="flex items-center gap-3">
-              <Logo width={28} height={28} className="shrink-0 opacity-70" />
-              <span className="text-sm font-medium text-slate-500 dark:text-slate-400">
-                Diamond HPC
-              </span>
-            </div>
-
-            <nav className="flex flex-wrap items-center justify-center gap-x-6 gap-y-2">
-              <Link
-                href="https://docs.diamondhpc.ai"
-                target="_blank"
-                rel="noopener noreferrer"
-                className="text-sm text-slate-500 transition-colors hover:text-slate-700 dark:text-slate-400 dark:hover:text-slate-200"
-              >
-                Docs
-              </Link>
-              <Link
-                href="/dashboard"
-                className="text-sm text-slate-500 transition-colors hover:text-slate-700 dark:text-slate-400 dark:hover:text-slate-200"
-              >
-                Workspace
-              </Link>
-            </nav>
-
-            <p className="text-xs text-slate-400 dark:text-slate-500">
-              &copy; {new Date().getFullYear()} Diamond HPC
-            </p>
-          </div>
-        </div>
-      </footer>
+      <LandingFooter />
     </main>
   );
 }

--- a/src/components/layout/app-shell.tsx
+++ b/src/components/layout/app-shell.tsx
@@ -8,7 +8,7 @@ import {
 } from 'react';
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
-import { Menu, PanelLeftClose, PanelLeftOpen, X } from 'lucide-react';
+import { LifeBuoy, Menu, PanelLeftClose, PanelLeftOpen, X } from 'lucide-react';
 
 import {
   ApiErrorMonitor,
@@ -24,6 +24,7 @@ import { Toaster } from '@/components/ui/toaster';
 import { AuthSessionProvider } from '@/lib/auth/session-context';
 import { useAuthSession } from '@/lib/auth/useAuthSession';
 import type { AuthSession } from '@/lib/auth/types';
+import contact from '@/content/contact.json';
 
 const routeTitles = [
   { match: (path: string) => path === '/dashboard', title: 'Dashboard' },
@@ -35,7 +36,8 @@ const routeTitles = [
     match: (path: string) => path.startsWith('/endpoints'),
     title: 'Endpoints'
   },
-  { match: (path: string) => path.startsWith('/profile'), title: 'Profile' }
+  { match: (path: string) => path.startsWith('/profile'), title: 'Profile' },
+  { match: (path: string) => path.startsWith('/contact'), title: 'Contact us' }
 ];
 
 const DESKTOP_NAV_COLLAPSED_STORAGE_KEY = 'diamond:desktop-nav-collapsed';
@@ -195,6 +197,16 @@ export function AppShell({
 
               <div className="flex items-center gap-3">
                 <ApiErrorMonitorTrigger />
+                <Link
+                  href={contact.navigation.href}
+                  className="inline-flex h-9 items-center justify-center gap-2 rounded-lg border border-slate-300/70 px-2.5 text-sm font-medium text-slate-700 transition-colors hover:bg-slate-100 focus-visible:ring-2 focus-visible:ring-primary/40 focus-visible:outline-none dark:border-slate-600 dark:text-slate-200 dark:hover:bg-slate-800"
+                  aria-label={contact.navigation.label}
+                >
+                  <LifeBuoy className="h-4 w-4" aria-hidden="true" />
+                  <span className="hidden xl:inline">
+                    {contact.navigation.label}
+                  </span>
+                </Link>
                 <DocsButton />
                 <ThemeToggle />
                 <AuthStatus session={session} isLoading={isLoading} />

--- a/src/content/contact.json
+++ b/src/content/contact.json
@@ -1,0 +1,30 @@
+{
+  "page": {
+    "title": "Contact us"
+  },
+  "emails": [
+    {
+      "name": "Dr. Zhao Zhang",
+      "email": "zz671@soe.rutgers.edu",
+      "role": "Rutgers University · Electrical & Computer Engineering",
+      "bio": "Dr. Zhang’s research brings high-performance computing and deep learning together across optimization, I/O, systems architecture, and scientific applications. Before joining Rutgers, he led the machine learning group at the Texas Advanced Computing Center. He received his Ph.D. in Computer Science from the University of Chicago and was a postdoctoral researcher at UC Berkeley’s AMPLab."
+    }
+  ],
+  "slack": {
+    "label": "Slack",
+    "joinUrl": "",
+    "status": "Invite link coming soon"
+  },
+  "github": [
+    {
+      "label": "Frontend repository",
+      "repositoryUrl": "https://github.com/Diamond-Proj/diamond-admin-dashboard",
+      "issuesUrl": "https://github.com/Diamond-Proj/diamond-admin-dashboard/issues/new/choose",
+      "pullRequestsUrl": "https://github.com/Diamond-Proj/diamond-admin-dashboard/pulls"
+    }
+  ],
+  "navigation": {
+    "label": "Contact us",
+    "href": "/contact"
+  }
+}

--- a/src/lib/auth/constants.ts
+++ b/src/lib/auth/constants.ts
@@ -10,8 +10,14 @@ export const LOGIN_ROUTE = '/login';
 export const LOGOUT_ROUTE = '/logout';
 export const SIGN_IN_ROUTE = '/sign-in';
 export const AUTH_CALLBACK_ROUTE = '/auth/callback';
+export const CONTACT_ROUTE = '/contact';
 
-export const PUBLIC_AUTH_ROUTES = [HOME_ROUTE, SIGN_IN_ROUTE, AUTH_CALLBACK_ROUTE] as const;
+export const PUBLIC_AUTH_ROUTES = [
+  HOME_ROUTE,
+  SIGN_IN_ROUTE,
+  AUTH_CALLBACK_ROUTE,
+  CONTACT_ROUTE
+] as const;
 export const AUTH_EXEMPT_API_ROUTES = ['/api/auth', '/api/healthcheck'] as const;
 export const CLIENT_AUTH_REDIRECT_EXEMPT_ROUTES = [
   ...PUBLIC_AUTH_ROUTES,


### PR DESCRIPTION
## Summary

- Add a public Contact Us page for Diamond HPC
- Display Slack, GitHub, and team email contact options
- Store extensible contact information in `src/content/contact.json`
- Add Contact Us entry points to the landing header, footer, and workspace header
- Extract a shared landing footer for reuse
- Add responsive hover transitions, dark mode styling, and reduced-motion support
- Allow `/contact` to be accessed without authentication
<!--- Provide a summary of the changes --->

<img width="640" height="430" alt="image" src="https://github.com/user-attachments/assets/6cd01a73-9e90-4344-a9cd-bb12837ca132" />


## Related Issues
<!--- List any issue numbers above that this PR addresses --->

- Closes #XX
- Related to #XX _(if applicable)_

## Changes
<!--- Check which of the following changes were made --->

- [ ] Breaking (backwards incompatible changes to public interfaces)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change or feature addition)
- [ ] Documentation (no changes to the code)
- [ ] Infrastructure (Github actions, Testing infra etc)


## Testing
<!--- Please describe the test ran to verify changes --->

N/A

## Pull Request Checklist

Please confirm the PR meets the following requirements.
- [ ] Relevant tags are added based on the types of changes.
- [ ] Tests have been added to show the fix is effective or that the new feature works.
- [ ] New and existing unit tests pass locally with the changes.
- [ ] Reviewers and Assignees are assigned.
